### PR TITLE
bash-plugin: rbenv でインストールされた ruby で実行するために必要なファイルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ sudo vi config.rb
 sudo bundle install --path vendor/bundle --deployment
 cd /etc/munin/plugins
 sudo ln -s /opt/munin-ircmap/irc_map .
+sudo -u munin munin-run irc_map
+sudo -u munin munin-run irc_map config
 sudo systemctl reload munin-node
 ```
 

--- a/bash-plugins/irc_channels
+++ b/bash-plugins/irc_channels
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# autoconf
+#%# family=auto
+#%# capabilities=autoconf
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+source /etc/profile.d/rbenv.sh
+cd /opt/munin-ircmap
+
+# config
+if [ "$1" = "config" ]; then
+	bundle exec ruby irc_channels config
+	exit 0
+fi
+
+# get values
+bundle exec ruby irc_channels

--- a/bash-plugins/irc_clients
+++ b/bash-plugins/irc_clients
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# autoconf
+#%# family=auto
+#%# capabilities=autoconf
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+source /etc/profile.d/rbenv.sh
+cd /opt/munin-ircmap
+
+# config
+if [ "$1" = "config" ]; then
+	bundle exec ruby irc_clients config
+	exit 0
+fi
+
+# get values
+bundle exec ruby irc_clients

--- a/bash-plugins/irc_map
+++ b/bash-plugins/irc_map
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# autoconf
+#%# family=auto
+#%# capabilities=autoconf
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+source /etc/profile.d/rbenv.sh
+cd /opt/munin-ircmap
+
+# config
+if [ "$1" = "config" ]; then
+	bundle exec ruby irc_map config
+	exit 0
+fi
+
+# get values
+bundle exec ruby irc_map


### PR DESCRIPTION
munin の plugins ディレクトリに配置するスクリプトを bash-plugins ディレクトリ内部のものに置き換える形で使用する